### PR TITLE
Add liquibase support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <spring-cloud.version>2021.0.3</spring-cloud.version>
         <testcontainers.version>1.17.3</testcontainers.version>
         <org.springframework.version>2.7.3</org.springframework.version>
+        <liquibase.version>4.19.0</liquibase.version>
     </properties>
     <dependencies>
         <dependency>
@@ -91,6 +92,11 @@
             <groupId>de.uni-stuttgart.gamify-it</groupId>
             <artifactId>authentification-validator</artifactId>
             <version>v1.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <version>${liquibase.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,6 @@ overworld.url=http://localhost/overworld/api/v1
 
 keycloak.issuer=http://localhost/keycloak/realms/Gamify-IT
 keycloak.url=http://localhost/keycloak/realms/Gamify-IT
+
+spring.liquibase.change-log=classpath:db/changelog-root.xml
+

--- a/src/main/resources/db/changelog-root.xml
+++ b/src/main/resources/db/changelog-root.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd
+      http://www.liquibase.org/xml/ns/pro
+      http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd">
+<includeAll path="db/changelog/"/><!-- Automatically queries all files in this directory in lexical order -->
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-1.0.sql
+++ b/src/main/resources/db/changelog/changelog-1.0.sql
@@ -1,0 +1,20 @@
+-- liquibase formatted sql
+
+-- changeset leon:change1-1
+CREATE TABLE "configuration_questions" ("configuration_id" UUID NOT NULL, "questions_id" UUID NOT NULL, CONSTRAINT "configuration_questions_pkey" PRIMARY KEY ("configuration_id", "questions_id"));
+
+-- changeset leon:change1-2
+ALTER TABLE "configuration_questions" ADD CONSTRAINT "uk_87jmj05cn4rqb8wfq6qxej42w" UNIQUE ("questions_id");
+
+-- changeset leon:change1-3
+CREATE TABLE "configuration" ("id" UUID NOT NULL, "name" VARCHAR(255) NOT NULL, CONSTRAINT "configuration_pkey" PRIMARY KEY ("id"));
+
+-- changeset leon:change1-4
+CREATE TABLE "question" ("id" UUID NOT NULL, "answer" VARCHAR(255) NOT NULL, "question_text" VARCHAR(255) NOT NULL, CONSTRAINT "question_pkey" PRIMARY KEY ("id"));
+
+-- changeset leon:change1-5
+ALTER TABLE "configuration_questions" ADD CONSTRAINT "fkewy22y8x7me09uka66yaovavm" FOREIGN KEY ("questions_id") REFERENCES "question" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- changeset leon:change1-6
+ALTER TABLE "configuration_questions" ADD CONSTRAINT "fkpuxg1dtbsi0no6cj8ynv0f8tt" FOREIGN KEY ("configuration_id") REFERENCES "configuration" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+


### PR DESCRIPTION
In the future, any PR that changes stored data must also adapt the corresponding changelog under `src/main/resources/db/changelog/changelog-<version>.sql`.
New versions should also use a new changelog instead of appending to an old one.
For details on how to keep the changelog up to date, consult the docs.
Part of Gamify-IT/issues#439.
Replaces #28.